### PR TITLE
FIX - 카메라 아이콘 깨지는 문제

### DIFF
--- a/assets/stylesheets/pc/app/products/reviews.css.scss
+++ b/assets/stylesheets/pc/app/products/reviews.css.scss
@@ -100,8 +100,6 @@ body.products.reviews, #review-edit-form {
     }
 
     .sprites-camera {
-      width: 10px;
-      height: 12px;
       display: block;
       position: absolute;
       top: 7px;


### PR DESCRIPTION
### 이유
- sprites는 자동으로 크기가 측정되는데 잘못된 값이 입력되어 있었다.

https://app.asana.com/0/search/292519521653687/305519286566520